### PR TITLE
Fix state reuse bug

### DIFF
--- a/game_controller.py
+++ b/game_controller.py
@@ -326,7 +326,9 @@ class GameController:
         last_turn_state = None
         if self.prev_state is not None:
             last_turn_state = self.prev_state
-        self.prev_state = self.state
+        # Store a deep copy of the current state so future updates do not
+        # mutate the previous state used for learning.
+        self.prev_state = copy.deepcopy(self.state)
 
         piece = chosen_action[0]
         offset = chosen_action[1]


### PR DESCRIPTION
## Summary
- ensure previous game state isn't mutated by later moves

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6868a6d9b7e08332a2acd5510d7a2d16